### PR TITLE
chore: add CIDR functions, tests, and more documentation for a clean PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build/
 duckdb_unittest_tempdir/
+.zed/
+.vscode/
+.ccache/

--- a/src/include/inet_functions.hpp
+++ b/src/include/inet_functions.hpp
@@ -34,6 +34,7 @@ struct INetFunctions {
                            Vector &result);
   static void ContainsRight(DataChunk &args, ExpressionState &state,
                             Vector &result);
+  static void ExpandCIDR(DataChunk &args, ExpressionState &state, Vector &result);
 };
 
 } // namespace duckdb

--- a/src/include/ipaddress.hpp
+++ b/src/include/ipaddress.hpp
@@ -43,6 +43,7 @@ public:
   static bool TryParse(string_t input, IPAddress &result,
                        CastParameters &parameters);
   static IPAddress FromString(string_t input);
+  bool IsCIDR();
 
   string ToString() const;
   IPAddress Netmask() const;

--- a/src/inet_extension.cpp
+++ b/src/inet_extension.cpp
@@ -75,6 +75,10 @@ void InetExtension::Load(DuckDB &db) {
                                   ScalarFunction(">>=", {inet_type, inet_type},
                                                  LogicalType::BOOLEAN,
                                                  INetFunctions::ContainsRight));
+  ExtensionUtil::RegisterFunction(
+        *db.instance,
+        ScalarFunction("expand_cidr", {inet_type}, LogicalType::LIST(inet_type),
+        INetFunctions::ExpandCIDR));
 }
 
 std::string InetExtension::Name() { return "inet"; }

--- a/src/ipaddress.cpp
+++ b/src/ipaddress.cpp
@@ -437,6 +437,11 @@ static string ToStringIPv6(const IPAddress &addr) {
   return result.str();
 }
 
+bool IPAddress::IsCIDR() {
+    return (type == IPAddressType::IP_ADDRESS_V4 && mask < IPV4_DEFAULT_MASK) ||
+           (type == IPAddressType::IP_ADDRESS_V6 && mask < IPV6_DEFAULT_MASK);
+}
+
 string IPAddress::ToString() const {
   if (type == IPAddressType::IP_ADDRESS_V4) {
     return ToStringIPv4(this->address, this->mask);

--- a/test/sql/test_inet_cidr_expansion.test
+++ b/test/sql/test_inet_cidr_expansion.test
@@ -1,0 +1,32 @@
+# name: test/sql/inet/test_inet_cidr_expansion.test
+# description: Test inet cidr expansion function
+# group: [inet]
+
+require inet
+
+statement ok
+PRAGMA enable_verification
+
+# basic expansion
+query I
+SELECT expand_cidr(inet '192.168.1.0/30');
+----
+[192.168.1.0, 192.168.1.1, 192.168.1.2, 192.168.1.3]
+
+# bare ip
+query I
+SELECT expand_cidr(inet '192.168.1.0');
+----
+[192.168.1.0]
+
+# ipv6
+query I
+SELECT expand_cidr(inet '2001:db8::/126');
+----
+[2001:db8::, 2001:db8::1, 2001:db8::2, 2001:db8::3]
+
+# bare ipv6
+query I
+SELECT expand_cidr('2603:3005:1507:5900:9c2b:2430:c08e:addf'::INET);
+----
+[2603:3005:1507:5900:9c2b:2430:c08e:addf]


### PR DESCRIPTION
Added:

- `bool IsCIDR()` to test whether there is a CIDR component
- `void INetFunctions::ExpandCIDR(DataChunk & args, ExpressionState & state, Vector & result)` to perform the CIDR expansion
- file: `test_inet_cidr_expansion.test` with IPv4 and IPv6 tests

I can make any other changes necessary