### PR TITLE
Add IP range functions (aliases to <<= and >>=)

### DIFF
--- a/src/inet_extension.cpp
+++ b/src/inet_extension.cpp
@@ -62,6 +62,15 @@ static void LoadInternal(ExtensionLoader &loader) {
                          INetFunctions::Add);
   loader.AddFunctionOverload(add_fun);
 
+  // Add IP range functions
+  loader.RegisterFunction(
+      ScalarFunction("subnet_contained_by_or_equals", {inet_type, inet_type},
+                                                       LogicalType::BOOLEAN,
+                                                       INetFunctions::ContainsLeft));
+  loader.RegisterFunction(
+      ScalarFunction("subnet_contains_or_equals", {inet_type, inet_type},
+                                                   LogicalType::BOOLEAN,
+                                                   INetFunctions::ContainsRight));
   // Add IP range operators
   loader.RegisterFunction(ScalarFunction("<<=", {inet_type, inet_type},
                                                  LogicalType::BOOLEAN,


### PR DESCRIPTION
This PR adds the `subnet_contained_by_or_equals` and `subnet_contains_or_equals` functions that are respectively equivalent to the `<<=` and `>>=` operators. The operators are great but they are not compatible with common SQL dialects which results in syntax error when parsing the SQL query with a generic/ANSI parser.