### PR TITLE
Actually apply symbol hiding, add LTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ option(DUCKDB_WASM_EXTENSION "Whether compiling for Wasm target" OFF)
 
 set(EXTENSION_NAME inet)
 set(DUCKDB_EXTENSION_API_VERSION_UNSTABLE 1)
+
 ###
 # Configuration
 ###
@@ -29,6 +30,32 @@ if (DEFINED DUCKDB_EXTENSION_API_VERSION_UNSTABLE)
 endif()
 
 ###
+#LTO
+###
+if (CMAKE_BUILD_TYPE STREQUAL "Release" AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.9")
+    cmake_policy(SET CMP0069 NEW)
+    set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
+
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT LTO_SUPPORTED OUTPUT LTO_ERROR)
+    if(LTO_SUPPORTED)
+        message(STATUS "LTO enabled")
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    else()
+        message(STATUS "LTO not available: <${LTO_ERROR}>")
+    endif()
+endif()
+
+###
+# Hide symbols
+###
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(VISIBILITY_INLINES_HIDDEN ON)
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+
+###
 # Build
 ###
 # Create Extension library
@@ -47,12 +74,6 @@ endif()
 # for building with DuckDB - FIXME - this needs to be reconciled somehow
 # build_loadable_extension_capi_unstable(${EXTENSION_NAME} ${EXTENSION_SOURCES})
 
-# Hide symbols
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_C_VISIBILITY_PRESET hidden)
-set(VISIBILITY_INLINES_HIDDEN ON)
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
 
 # Include own headers
 target_include_directories(${EXTENSION_NAME} PRIVATE src)


### PR DESCRIPTION
The symbol visibility configuration needs to be set __before__ the library target is created, or it won't apply.

I've also added support for CMake 3.9+ LTO, but it doesn't seem to make any difference on binary size at least. As far as I can tell `CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE` adds "thin" LTO, but It seems possible to optimize more aggressively with "fat" LTO. E.g. manually setting`-flto=full` using clang shrinks binary size by another 10KB, but that requires passing compiler-specific options, so I think this is good for now.