### PR TITLE
Fix ODR Violation leading to loader crashes

### DIFF
--- a/src/include/html_charref.hpp
+++ b/src/include/html_charref.hpp
@@ -4570,9 +4570,9 @@ private:
 };
 
 // definition of the static members
-const vector<string> HTML5NameCharrefs::owned_strings =
+const inline vector<string> HTML5NameCharrefs::owned_strings =
     HTML5NameCharrefs::initialize_vector();
-const string_map_t<HTMLEscapeCodepoint> HTML5NameCharrefs::mapped_strings =
+const inline string_map_t<HTMLEscapeCodepoint> HTML5NameCharrefs::mapped_strings =
     HTML5NameCharrefs::initialize_map();
 
 } // namespace duckdb


### PR DESCRIPTION
Compiling without this patch led to crashes on initialization of static symbols:

In `initialize_map` the `owned_strings` were not initialized yet; leading to index out of bounds errors when accessing them.

Stack trace before the fix:
```
__cxa_throw 0x00000001178723ec
duckdb::vector::AssertIndexInBounds(unsigned long long, unsigned long long) vector.hpp:35
duckdb::vector::get<…>(unsigned long) const vector.hpp:70
duckdb::vector::operator[](unsigned long) const vector.hpp:79
duckdb::HTML5NameCharrefs::initialize_map() html_charref.hpp:2334
::__cxx_global_var_init.28() html_charref.hpp:4576
_GLOBAL__sub_I_inet_escape_functions.cpp inet_escape_functions.cpp:0
invocation function for block in dyld4::Loader::findAndRunAllInitializers(dyld4::RuntimeState&) const 0x000000018a79eefc
invocation function for block in dyld3::MachOAnalyzer::forEachInitializer(Diagnostics&, dyld3::MachOAnalyzer::VMAddrConverter const&, void (unsigned int) block_pointer, void const*) const 0x000000018a7db678
invocation function for block in mach_o::Header::forEachSection(void (mach_o::Header::SectionInfo const&, bool&) block_pointer) const 0x000000018a7fb5cc
mach_o::Header::forEachLoadCommand(void (load_command const*, bool&) block_pointer) const 0x000000018a7f8358
mach_o::Header::forEachSection(void (mach_o::Header::SectionInfo const&, bool&) block_pointer) const 0x000000018a7f9a98
dyld3::MachOFile::forEachInitializerPointerSection(Diagnostics&, void (unsigned int, unsigned int, bool&) block_pointer) const 0x000000018a7d0ba0
dyld3::MachOAnalyzer::forEachInitializer(Diagnostics&, dyld3::MachOAnalyzer::VMAddrConverter const&, void (unsigned int) block_pointer, void const*) const 0x000000018a7db318
dyld4::Loader::findAndRunAllInitializers(dyld4::RuntimeState &) const 0x000000018a79ecb4
dyld4::JustInTimeLoader::runInitializers(dyld4::RuntimeState &) const 0x000000018a7a6670
dyld4::Loader::runInitializersBottomUp(dyld4::RuntimeState &, dyld3::Array<…> &, dyld3::Array<…> &) const 0x000000018a79f460
dyld4::Loader::runInitializersBottomUp(dyld4::RuntimeState &, dyld3::Array<…> &, dyld3::Array<…> &) const 0x000000018a79f400
$_0::operator()() const 0x000000018a7a3bf0
dyld4::Loader::runInitializersBottomUpPlusUpwardLinks(dyld4::RuntimeState &) const 0x000000018a79f77c
dyld4::APIs::runAllInitializersForMain() 0x000000018a7c0a20
dyld4::prepare(dyld4::APIs &, const mach_o::Header *) 0x000000018a783e00
$_0::operator()() const 0x000000018a7831d8
start 0x000000018a782b4c
```


Compiler information
```
clang version 21.1.2
Target: arm64-apple-darwin
Thread model: posix
```