### PR TITLE
Add bit-wise operators for IP-addresses

### DIFF
--- a/src/inet_extension.cpp
+++ b/src/inet_extension.cpp
@@ -1,3 +1,5 @@
+#include "inet_extension.hpp"
+
 #include "duckdb_extension.h"
 #include "inet_html.hpp"
 #include "inet_ipaddress.hpp"
@@ -359,6 +361,55 @@ static INET_T AddImplementation(const INET_T &lhs, const hugeint_t &rhs) {
 
 }
 
+static INET_T AndImplementation(const INET_T &lhs, const INET_T &rhs) {
+	INET_EXECUTOR_TYPE result;
+	auto l_addr_type = (INET_IPAddressType) lhs.a_val,
+		 r_addr_type = (INET_IPAddressType) rhs.a_val;
+	if (l_addr_type != r_addr_type) {
+		throw TypeCompatibilityException("Cannot mix IPv4 and IPv6 addresses in bit-and");
+	}
+	duckdb_uhugeint address_out = from_compatible_address(lhs.b_val, l_addr_type),
+		another_address = from_compatible_address(rhs.b_val, r_addr_type);
+	address_out.lower &= another_address.lower;
+	address_out.upper &= another_address.upper;
+
+	result.a_val = lhs.a_val;
+	result.b_val = to_compatible_address(address_out, l_addr_type);
+	result.c_val = lhs.c_val;
+	return result;
+}
+
+static INET_T OrImplementation(const INET_T &lhs, const INET_T &rhs) {
+	INET_EXECUTOR_TYPE result;
+	auto l_addr_type = (INET_IPAddressType) lhs.a_val,
+		 r_addr_type = (INET_IPAddressType) rhs.a_val;
+	if (l_addr_type != r_addr_type) {
+		throw TypeCompatibilityException("Cannot mix IPv4 and IPv6 addresses in bit-or");
+	}
+	duckdb_uhugeint address_out = from_compatible_address(lhs.b_val, l_addr_type),
+		another_address = from_compatible_address(rhs.b_val, r_addr_type);
+	address_out.lower |= another_address.lower;
+	address_out.upper |= another_address.upper;
+
+	result.a_val = lhs.a_val;
+	result.b_val = to_compatible_address(address_out, l_addr_type);
+	result.c_val = lhs.c_val;
+	return result;
+}
+
+static INET_T InvertImplementation(const INET_T &input) {
+	INET_EXECUTOR_TYPE result;
+	auto l_addr_type = (INET_IPAddressType) input.a_val;
+	duckdb_uhugeint address_out = from_compatible_address(input.b_val, l_addr_type);
+	address_out.lower = ~address_out.lower;
+	address_out.upper = ~address_out.upper;
+
+	result.a_val = input.a_val;
+	result.b_val = to_compatible_address(address_out, l_addr_type);
+	result.c_val = input.c_val;
+	return result;
+}
+
 class AddFunction : public BinaryFunction<AddFunction, INET_EXECUTOR_TYPE, PrimitiveType<hugeint_t>, INET_EXECUTOR_TYPE> {
 public:
 	const char *Name() const override {
@@ -376,6 +427,36 @@ public:
 	}
 	static RESULT_TYPE::ARG_TYPE Operation(const A_TYPE::ARG_TYPE &lhs, const B_TYPE::ARG_TYPE &rhs) {
 		return AddImplementation(lhs, rhs.negate());
+	}
+};
+
+class AndFunction : public BinaryFunction<AndFunction, INET_EXECUTOR_TYPE, INET_EXECUTOR_TYPE, INET_EXECUTOR_TYPE> {
+public:
+	const char *Name() const override {
+		return "&";
+	}
+	static INET_EXECUTOR_TYPE::ARG_TYPE Operation(const A_TYPE::ARG_TYPE &lhs, const B_TYPE::ARG_TYPE &rhs)	{
+		return AndImplementation(lhs, rhs);
+	}
+};
+
+class OrFunction : public BinaryFunction<OrFunction, INET_EXECUTOR_TYPE, INET_EXECUTOR_TYPE, INET_EXECUTOR_TYPE> {
+public:
+	const char *Name() const override {
+		return "|";
+	}
+	static RESULT_TYPE::ARG_TYPE Operation(const A_TYPE::ARG_TYPE &lhs, const B_TYPE::ARG_TYPE &rhs) {
+		return OrImplementation(lhs, rhs);
+	}
+};
+
+class InvertFunction : public UnaryFunction<InvertFunction, INET_EXECUTOR_TYPE, INET_EXECUTOR_TYPE> {
+public:
+	const char *Name() const override {
+		return "~";
+	}
+	static RESULT_TYPE::ARG_TYPE Operation(const INPUT_TYPE::ARG_TYPE &input) {
+		return InvertImplementation(input);
 	}
 };
 
@@ -530,6 +611,15 @@ DUCKDB_EXTENSION_CPP_ENTRYPOINT(INET) {
 
 	SubtractFunction subtract_function;
 	Register(subtract_function);
+
+	AndFunction and_function;
+	Register(and_function);
+
+	OrFunction or_function;
+	Register(or_function);
+
+	InvertFunction invert_function;
+	Register(invert_function);
 
 	ContainsLeftFunction contains_left;
 	Register(contains_left);

--- a/src/inet_extension.hpp
+++ b/src/inet_extension.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifndef INET_INET_EXTENSION_HPP
+#define INET_INET_EXTENSION_HPP
+#include "duckdb/stable/exception.hpp"
+
+#include <string>
+
+class TypeCompatibilityException : public duckdb_stable::Exception {
+public:
+	explicit TypeCompatibilityException(const std::string &msg) : duckdb_stable::Exception("Type Compatibility Exception: " + msg) {}
+	template <typename... ARGS>
+	explicit TypeCompatibilityException(const std::string &msg, ARGS... params)
+		: TypeCompatibilityException(ConstructMessage(msg, params...)) {
+	}
+};
+
+
+#endif // INET_INET_EXTENSION_HPP

--- a/test/sql/inet/test_inet_operations.test
+++ b/test/sql/inet/test_inet_operations.test
@@ -119,3 +119,99 @@ query I
 SELECT inet '0.0.0.0/0' <<= inet '192.168.1.0/0'
 ----
 true
+
+# bit-and
+query I
+SELECT inet '1.2.3.4/8' &  inet '0.0.255.255'
+----
+0.0.3.4/8
+
+# one more
+query I
+SELECT inet '1.2.3.4/8' &  inet '1.1.1.1'
+----
+1.0.1.0/8
+
+# the 2-nd operand's net mask is ignored
+query I
+SELECT inet '1.2.3.4/8' &  inet '1.1.1.1/32'
+----
+1.0.1.0/8
+
+# zero-sized one is ignored as well
+query I
+SELECT inet '1.2.3.4/8' &  inet '1.1.1.1/0'
+----
+1.0.1.0/8
+
+# string operand is casted to inet automatically
+query I
+SELECT inet '1.2.3.4/8' & '1.1.1.1/0'
+----
+1.0.1.0/8
+
+# string operand is casted to inet automatically
+query I
+SELECT inet '1.2.3.4/8' & '1.1.1.1/0'
+----
+1.0.1.0/8
+
+# the first one also
+query I
+SELECT '1.2.3.4/8' & inet '1.1.1.1/0'
+----
+1.0.1.0/8
+
+# bit-or
+query I
+SELECT inet '1.2.3.4/8' |  inet '0.0.255.255'
+----
+1.2.255.255/8
+
+# one more
+query I
+SELECT inet '1.2.3.4/8' |  inet '1.1.1.1'
+----
+1.3.3.5/8
+
+# the 2-nd operand's net mask is ignored
+query I
+SELECT inet '1.2.3.4/8' |  inet '1.1.1.1/32'
+----
+1.3.3.5/8
+
+# zero-sized one is ignored as well
+query I
+SELECT inet '1.2.3.4/8' |  inet '1.1.1.1/0'
+----
+1.3.3.5/8
+
+# string operand is casted to inet automatically
+query I
+SELECT inet '1.2.3.4/8' | '1.1.1.1/0'
+----
+1.3.3.5/8
+
+# string operand is casted to inet automatically
+query I
+SELECT inet '1.2.3.4/8' | '1.1.1.1/0'
+----
+1.3.3.5/8
+
+# the first one also
+query I
+SELECT '1.2.3.4/8' | inet '1.1.1.1/0'
+----
+1.3.3.5/8
+
+# bitwise inversion
+query I
+select  ~(inet '1.2.3.4')
+----
+254.253.252.251
+
+# bitwise inversion preserves netmask
+query I
+select  ~(inet '1.2.3.4/8')
+----
+254.253.252.251/8


### PR DESCRIPTION
Add bit-wise operators ("&", "|" and "~") for the IP-addresses.

The ability to perform bit-wise operations on IP addresses and masks seems highly desirable for manipulating network traffic data during investigations of various network incidents. The lack of bit-wise operations and the resulting need for external scripts creates significant inconvenience, so the proposed addition seems quite useful.

The only drawback of the proposed solution appears to be the inability to meaningfully interpret binary bit-wise operations on the network mask. In this implementation, the mask of the first operand is arbitrarily copied into the result. This violates the commutativity of operations, but this sacrifice of purity for ease of manipulation does not seem particularly significant.